### PR TITLE
removed the old nrpe_puppet check

### DIFF
--- a/manifests/standard_checks.pp
+++ b/manifests/standard_checks.pp
@@ -9,7 +9,7 @@ class nagios::standard_checks {
     include nagios::plugin::nrpe_zombies
     include nagios::plugin::nrpe_procs
     include nagios::plugin::nrpe_memory
-    include nagios::plugin::nrpe_puppet
+    #include nagios::plugin::nrpe_puppet
     include nagios::plugin::check_ssh
     include nagios::plugin::check_ping
   }


### PR DESCRIPTION
Removes the old puppet check allowing the new one to take over