### PR TITLE
Resolved graphios issue

### DIFF
--- a/manifests/graphios.pp
+++ b/manifests/graphios.pp
@@ -11,7 +11,7 @@ class nagios::graphios (
     provider => 'pip',
   }
 
-  file { $perfdata_dir:
+  file { [$perfdata_dir, '/etc/graphios']:
     ensure => 'directory',
     owner  => 'nagios',
   }

--- a/manifests/graphios.pp
+++ b/manifests/graphios.pp
@@ -36,6 +36,7 @@ class nagios::graphios (
   file { '/etc/graphios/graphios.cfg':
     ensure  => 'file',
     content => epp('nagios/graphios.cfg.epp', {graphite_host => $graphite_host }),
+    require => File['/etc/graphios'],
     notify  => Package['graphios'],
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,6 +15,7 @@ class nagios::server (
   String $contact_config         = $nagios::params::contact_config,
   String $contactgroup_config    = $nagios::params::contactgroup_config,
   String $timeperiod_config      = $nagios::params::timeperiod_config,
+  String $graphios_perfdata_dir  = lookup('nagios::graphios::perfdata_dir'),
   Hash $nagios_extra_hosts       = {}
 ){
 
@@ -169,7 +170,7 @@ class nagios::server (
   include nagios::collect_checks
 
   # Configure Puppet node state checks
-  if $puppetdb_check_enable == true {
+  if $puppetdb_check_enable {
     include nagios::puppetdb
   }
 

--- a/templates/nagios.cfg.epp
+++ b/templates/nagios.cfg.epp
@@ -791,11 +791,10 @@ enable_event_handlers=1
 # performance data.
 # Values: 1 = process performance data, 0 = do not process performance data
 
-<% if $nagios::server::graphios_install == false { -%>
+<% unless $nagios::server::graphios_install { -%>
 process_performance_data=0
 <% } else { -%>
 process_performance_data=1
-
 
 
 # HOST AND SERVICE PERFORMANCE DATA PROCESSING COMMANDS
@@ -818,8 +817,8 @@ process_performance_data=1
 
 #host_perfdata_file=/var/log/nagios/host-perfdata
 #service_perfdata_file=/var/log/nagios/service-perfdata
-host_perfdata_file=<%= $nagios::graphios::perfdata_dir %>/host-perfdata
-service_perfdata_file=<%= $nagios::graphios::perfdata_dir %>/service-perfdata
+host_perfdata_file=<%= $nagios::server::graphios_perfdata_dir %>/host-perfdata
+service_perfdata_file=<%= $nagios::server::graphios_perfdata_dir %>/service-perfdata
 
 
 


### PR DESCRIPTION
Graphios perfdata directory was not being specified correctly in nagios.cfg template. Resolved this issue by adding in a global variable for the nagios::server manifest allowing the template to reference the graphios perfdata directory by using a hiera lookup.

Also changed the if-statement in the template to an unless-statement.

Also added in a file resource to create /etc/graphios directory that was missing and causes puppet run to fail.