### PR TITLE
Task/resolve timeperiod errors

### DIFF
--- a/files/nagios_timeperiods.cfg
+++ b/files/nagios_timeperiods.cfg
@@ -94,7 +94,7 @@ define timeperiod {
 
     name                    workhours
     timeperiod_name         workhours
-    alias                   MoE work hours, weekdays only
+    alias                   MoE work hours, weekdays only dupe of work_hours
 
     monday                  06:00-19:00
     tuesday                 06:00-19:00

--- a/files/nagios_timeperiods.cfg
+++ b/files/nagios_timeperiods.cfg
@@ -48,7 +48,7 @@ define timeperiod {
 define timeperiod {
 
     name                    24x7_minus_holidays
-    timeperiod_name         24x7 minus holidays
+    timeperiod_name         24x7_minus_holidays
     alias                   24 Hours A Day, 7 Days A Week, except holidays
 
     use                     nz-holidays     ; Get holiday exceptions from other timeperiod
@@ -78,7 +78,7 @@ define timeperiod {
 define timeperiod {
 
     name                    work_hours_minus_holidays
-    timeperiod_name         work_hours minus holidays
+    timeperiod_name         work_hours_minus_holidays
     alias                   MoE work hours, weekdays only, except holidays
 
     use                     nz-holidays     ; Get holiday exceptions from other timeperiod

--- a/files/nagios_timeperiods.cfg
+++ b/files/nagios_timeperiods.cfg
@@ -48,7 +48,7 @@ define timeperiod {
 define timeperiod {
 
     name                    24x7_minus_holidays
-    timeperiod_name         24x7
+    timeperiod_name         24x7 minus holidays
     alias                   24 Hours A Day, 7 Days A Week, except holidays
 
     use                     nz-holidays     ; Get holiday exceptions from other timeperiod
@@ -78,10 +78,23 @@ define timeperiod {
 define timeperiod {
 
     name                    work_hours_minus_holidays
-    timeperiod_name         work_hours
+    timeperiod_name         work_hours minus holidays
     alias                   MoE work hours, weekdays only, except holidays
 
     use                     nz-holidays     ; Get holiday exceptions from other timeperiod
+
+    monday                  06:00-19:00
+    tuesday                 06:00-19:00
+    wednesday               06:00-19:00
+    thursday                06:00-19:00
+    friday                  06:00-19:00
+}
+
+define timeperiod {
+
+    name                    workhours
+    timeperiod_name         workhours
+    alias                   MoE work hours, weekdays only
 
     monday                  06:00-19:00
     tuesday                 06:00-19:00


### PR DESCRIPTION
fixed some syntax issues in nagios_timeperiods.cfg and added workhours section (duplicate of work_hours) as this was previously removed