### PR TITLE
Task/edgazette monitoring

### DIFF
--- a/files/grep_file.sh
+++ b/files/grep_file.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# 
+# WARNING: This file is managed by Puppet and any local changes will be overwritten!!
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Nagios script to grep through a file, searching for a provided phrase and alerting based upon
+# provided alert value
+#
+# Created for:
+# ------------ Ministry of Education, Nagios monitoring via Puppet
+#
+# Created date and author:
+# ------------ 18/03/2020, Jasper Connery
+#
+# Updated on and by:
+# ------------
+#
+# Usage:
+# -----  This script requires three arguments, the first being an identifier to show what the alert context is (e.g. Gazette), the second being
+#        the (full-path) file to grep through, and the third is a comma-delimited string of phrases or words to query, also containing the
+#        nagios alert state separated from the phrase by a hash #. 
+#        E.g:
+#             grep_file.sh 'Gazette' '/var/log/gazetteDB.log' 'Snapshot failed|Crit,No disk space|Crit,Timeout|Warning'
+#
+#        Each 'query' is processed in the order they appear - i.e. if 'Snapshot failed' is found, it will alert on that 
+#	       and exit the script, not continuing to search for 'No disk space' or 'Timeout'. 
+#
+#        The phrase to be searched for is case-insensitive
+#
+# Limitations: 
+# ----------- Cannot search for a phrase that contains a comma or '|''' - to be resolved (eventually)
+#
+
+
+# Save current IFS value and set IFS to comma delimiter
+OIFS=$IFS
+IFS=','
+
+# Alert identifier
+context=$1
+# Log file to grep through
+file=$2
+# Assign phrases and nagios alert states to an array of strings
+queries=($3)
+# Default exit code value - relates to UNKOWN alert for nagios
+exit_code=3
+
+# If file for grepping does not exist, exit script and alert
+if [ ! -f $file ]; then
+  echo "File ${file} does not exist!! Resolve syntax error for nagios check!"
+  exit 3
+fi
+
+# Loop through array searching for each query, ordered by first-in,first-checked
+for((i=0; i<${#queries[@]}; ++i)); do
+  # Separate out query and nagios alert value from array string
+  query="$(cut -d '|' -f1 <<< ${queries[$i]})"
+  state="$(cut -d '|' -f2 <<< ${queries[$i]})"
+  
+  # Set relevant exit codes
+  if [[ ${state,,} == *"crit"* ]]; then
+    exit_code=1
+  elif [[ ${state,,} == *"warn"* ]]; then
+    exit_code=2
+  fi
+  
+  # Search through file for obtained query, alerting and exiting script if found. ${foo^^} converts $foo value to uppercase, ${foo,,} to lowercase
+  if grep -Fqi "${query}" $file; then
+    echo "${state^^}: ${context} ${query,,}!"
+    IFS=$OIFS
+    exit $exit_code
+  fi
+done
+
+# If no errors found, gracefully exit script
+echo "OK: ${context} - no detected errors in ${file}."
+IFS=$OIFS
+exit 0

--- a/manifests/nagios_nrpe.pp
+++ b/manifests/nagios_nrpe.pp
@@ -42,6 +42,12 @@ class nagios::nagios_nrpe (
     notify => Service['nrpe'],
   }
 
+  nrpe::plugin { 'grep_file.sh':
+    ensure => present,
+    source => 'puppet:///modules/nagios/grep_file.sh',
+    notify => Service['nrpe'],
+  }
+
   # Allow NRPE user to run plugin checks as root
   sudo::conf { 'nrpe':
     content  => 'nrpe ALL=(ALL) NOPASSWD: /usr/lib64/nagios/plugins/',

--- a/manifests/plugin/check_gazette_snapshots.pp
+++ b/manifests/plugin/check_gazette_snapshots.pp
@@ -1,0 +1,29 @@
+# Export Nagios service to check yum patching state
+class nagios::plugin::check_gazette_snapshots (
+  Integer $notification_interval = lookup('nagios::notification_interval'),
+  String $notification_period    = lookup('nagios::notification_period'),
+  String $snapshot_errors        = 'Snapshot failed|Crit',
+){
+  # Configure nrpe directories first
+  include nrpe
+
+# NRPE Command
+
+  nrpe::command { 'check_gazette_snapshot':
+    ensure  => present,
+    command => "grep_file.sh '/var/log/gazetteDB.log' '${snapshot_errors}'",
+  }
+
+
+# Nagios Check
+  @@nagios_service { "check yum file ${::hostname}":
+    service_description   => 'EdGazette Snapshot Check',
+    check_command         => 'check_nrpe!check_gazette_snapshot',
+    host_name             => $::fqdn,
+    notify                => Service['nagios'],
+    tag                   => $::environment,
+    notification_interval => $notification_interval,
+    notification_period   => $notification_period,
+    require               => Class['nagios']
+  }
+}

--- a/manifests/plugin/check_gazette_snapshots.pp
+++ b/manifests/plugin/check_gazette_snapshots.pp
@@ -11,7 +11,7 @@ class nagios::plugin::check_gazette_snapshots (
 
   nrpe::command { 'check_gazette_snapshot':
     ensure  => present,
-    command => "grep_file.sh '/var/log/gazetteDB.log' '${snapshot_errors}'",
+    command => "grep_file.sh 'Gazette' '/var/log/gazetteDB.log' '${snapshot_errors}'",
   }
 
 


### PR DESCRIPTION
Created a script to allow file grepping and alerting via nagios. Utilised this script to setup an edgazette check for when a snapshot fails.


The grep_file.sh script is ambiguous in that you can use this for any case that fits the syntax.