### PR TITLE
remove non-ascii chars

### DIFF
--- a/files/check_memory
+++ b/files/check_memory
@@ -57,7 +57,6 @@ total=`free -m | grep "Mem:" | awk '{print $2}'`
 useAux=$((100*$used))
 result=$(($useAux/$total))
 
-## Código para debug
 if [ "$result" -lt "$warn_level" ]; then
     echo "Memory OK. $result% used. Using $used MB  out of $total MB| Memory=$result%;$warn_level;$critical_level"
     exit 0;


### PR DESCRIPTION
In the check_memory script, there was a comment with a non-ascii character that was causing issues when running Puppet sometimes.