### PR TITLE
Add check interval and check attempts variables for some nagios checks

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 # Set defaults for Nagios classes
-class nagios::params{
+class nagios::params {
   $role                  = 'client'
   $graphios_install      = true
   $slack_service_channel = '#nagios-alerts'
@@ -19,4 +19,6 @@ class nagios::params{
   $contactgroup_config   = '/etc/nagios/nagios_contactgroup.cfg'
   $timeperiod_config     = '/etc/nagios/nagios_timeperiods.cfg'
   $nrpe_timeout_seconds  = 30
+  $check_interval        = lookup('nagios::params::check_interval') # On an environment basis.
+  $max_check_attempts    = lookup('nagios::params::max_check_attempts') # On an environment basis.
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,6 @@ class nagios::params {
   $contactgroup_config   = '/etc/nagios/nagios_contactgroup.cfg'
   $timeperiod_config     = '/etc/nagios/nagios_timeperiods.cfg'
   $nrpe_timeout_seconds  = 30
-  $check_interval        = lookup('nagios::params::check_interval') # On an environment basis.
-  $max_check_attempts    = lookup('nagios::params::max_check_attempts') # On an environment basis.
+  $check_interval        = '1'
+  $max_check_attempts    = '5'
 }

--- a/manifests/plugin/check_ping.pp
+++ b/manifests/plugin/check_ping.pp
@@ -3,7 +3,9 @@ class nagios::plugin::check_ping (
   $warn                          = 30,
   $crit                          = 90,
   Integer $notification_interval = lookup('nagios::notification_interval'),
-  String $notification_period    = lookup('nagios::notification_period')
+  String $notification_period    = lookup('nagios::notification_period'),
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
+  String $check_interval         = $nagios::params::check_interval
 ){
 
 # Nagios Check
@@ -16,5 +18,7 @@ class nagios::plugin::check_ping (
     notification_interval => $notification_interval,
     notification_period   => $notification_period,
     require               => Class['nagios'],
+    check_interval        => $check_interval,
+    max_check_attempts    => $max_check_attempts,
   }
 }

--- a/manifests/plugin/check_ping.pp
+++ b/manifests/plugin/check_ping.pp
@@ -1,11 +1,11 @@
 # Export Nagios service for check_ping
 class nagios::plugin::check_ping (
+  String $max_check_attempts,
+  String $check_interval,
   $warn                          = 30,
   $crit                          = 90,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
-  String $max_check_attempts     = $nagios::params::max_check_attempts,
-  String $check_interval         = $nagios::params::check_interval
 ){
 
 # Nagios Check

--- a/manifests/plugin/check_ping.pp
+++ b/manifests/plugin/check_ping.pp
@@ -1,11 +1,11 @@
 # Export Nagios service for check_ping
 class nagios::plugin::check_ping (
-  String $max_check_attempts,
-  String $check_interval,
   $warn                          = 30,
   $crit                          = 90,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
+  String $check_interval         = $nagios::params::check_interval,
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
 ){
 
 # Nagios Check

--- a/manifests/plugin/nrpe_core_load.pp
+++ b/manifests/plugin/nrpe_core_load.pp
@@ -1,11 +1,11 @@
 # Export Nagios service for check_load
 class nagios::plugin::nrpe_core_load (
+  String $max_check_attempts,
+  String $check_interval,
   $warn                          = 3,
   $crit                          = 5,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
-  String $max_check_attempts     = $nagios::params::max_check_attempts,
-  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe

--- a/manifests/plugin/nrpe_core_load.pp
+++ b/manifests/plugin/nrpe_core_load.pp
@@ -1,11 +1,11 @@
 # Export Nagios service for check_load
 class nagios::plugin::nrpe_core_load (
-  String $max_check_attempts,
-  String $check_interval,
   $warn                          = 3,
   $crit                          = 5,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
+  String $check_interval         = $nagios::params::check_interval,
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
 ){
   # Configure nrpe directories first
   include nrpe

--- a/manifests/plugin/nrpe_core_load.pp
+++ b/manifests/plugin/nrpe_core_load.pp
@@ -3,7 +3,9 @@ class nagios::plugin::nrpe_core_load (
   $warn                          = 3,
   $crit                          = 5,
   Integer $notification_interval = lookup('nagios::notification_interval'),
-  String $notification_period    = lookup('nagios::notification_period')
+  String $notification_period    = lookup('nagios::notification_period'),
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
+  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe
@@ -24,5 +26,7 @@ class nagios::plugin::nrpe_core_load (
     notification_interval => $notification_interval,
     notification_period   => $notification_period,
     require               => Class['nagios'],
+    check_interval        => $check_interval,
+    max_check_attempts    => $max_check_attempts,
   }
 }

--- a/manifests/plugin/nrpe_disks.pp
+++ b/manifests/plugin/nrpe_disks.pp
@@ -1,5 +1,7 @@
 # Export Nagios service for check_disks
 class nagios::plugin::nrpe_disks (
+  String $max_check_attempts,
+  String $check_interval,
   $warn                          = '5%',
   $crit                          = '2%',
   # lint:ignore:140chars
@@ -7,8 +9,6 @@ class nagios::plugin::nrpe_disks (
   # lint:endignore
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
-  String $max_check_attempts     = $nagios::params::max_check_attempts,
-  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe

--- a/manifests/plugin/nrpe_disks.pp
+++ b/manifests/plugin/nrpe_disks.pp
@@ -1,7 +1,5 @@
 # Export Nagios service for check_disks
 class nagios::plugin::nrpe_disks (
-  String $max_check_attempts,
-  String $check_interval,
   $warn                          = '5%',
   $crit                          = '2%',
   # lint:ignore:140chars
@@ -9,6 +7,8 @@ class nagios::plugin::nrpe_disks (
   # lint:endignore
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
+  String $check_interval         = $nagios::params::check_interval,
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
 ){
   # Configure nrpe directories first
   include nrpe

--- a/manifests/plugin/nrpe_disks.pp
+++ b/manifests/plugin/nrpe_disks.pp
@@ -6,7 +6,9 @@ class nagios::plugin::nrpe_disks (
   $check_disks_command           = "check_disk -l -L -w ${warn} -c ${crit} -e -f -M -A -X configfs -X cgroup -X selinuxfs -X sysfs -X proc -X mqueue -X binfmt_misc -X devtmpfs",
   # lint:endignore
   Integer $notification_interval = lookup('nagios::notification_interval'),
-  String $notification_period    = lookup('nagios::notification_period')
+  String $notification_period    = lookup('nagios::notification_period'),
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
+  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe
@@ -27,5 +29,7 @@ class nagios::plugin::nrpe_disks (
     notification_interval => $notification_interval,
     notification_period   => $notification_period,
     require               => Class['nagios'],
+    check_interval        => $check_interval,
+    max_check_attempts    => $max_check_attempts,
   }
 }

--- a/manifests/plugin/nrpe_memory.pp
+++ b/manifests/plugin/nrpe_memory.pp
@@ -1,10 +1,12 @@
 # Export Nagios service for check_memory
-class nagios::plugin::nrpe_memory(
+class nagios::plugin::nrpe_memory (
   $ensure                        = 'present',
-  $warn                          = 90,
-  $crit                          = 95,
+  $warn                          = 75,
+  $crit                          = 85,
   Integer $notification_interval = lookup('nagios::notification_interval'),
-  String $notification_period    = lookup('nagios::notification_period')
+  String $notification_period    = lookup('nagios::notification_period'),
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
+  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe
@@ -21,7 +23,7 @@ class nagios::plugin::nrpe_memory(
   }
 
   @@nagios_service { "check_memory_${::hostname}":
-    service_description   => 'Memory Usage',
+    service_description   => 'Check Memory',
     check_command         => 'check_nrpe!check_memory',
     host_name             => $::fqdn,
     notify                => Service['nagios'],
@@ -29,6 +31,7 @@ class nagios::plugin::nrpe_memory(
     notification_interval => $notification_interval,
     notification_period   => $notification_period,
     require               => Class['nagios'],
+    check_interval        => $check_interval,
+    max_check_attempts    => $max_check_attempts,
   }
-
 }

--- a/manifests/plugin/nrpe_memory.pp
+++ b/manifests/plugin/nrpe_memory.pp
@@ -1,12 +1,12 @@
 # Export Nagios service for check_memory
 class nagios::plugin::nrpe_memory (
+  String $max_check_attempts,
+  String $check_interval,
   $ensure                        = 'present',
   $warn                          = 75,
   $crit                          = 85,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
-  String $max_check_attempts     = $nagios::params::max_check_attempts,
-  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe

--- a/manifests/plugin/nrpe_memory.pp
+++ b/manifests/plugin/nrpe_memory.pp
@@ -1,12 +1,12 @@
 # Export Nagios service for check_memory
 class nagios::plugin::nrpe_memory (
-  String $max_check_attempts,
-  String $check_interval,
   $ensure                        = 'present',
   $warn                          = 75,
   $crit                          = 85,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
+  String $check_interval         = $nagios::params::check_interval,
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
 ){
   # Configure nrpe directories first
   include nrpe
@@ -15,6 +15,11 @@ class nagios::plugin::nrpe_memory (
       ensure => present,
       source => 'puppet:///modules/nagios/check_memory',
       notify => Service['nrpe'],
+  }
+
+  file {'/opt/test':
+    ensure  => present,
+    content => "${check_interval} - ${max_check_attempts}"
   }
 
   nrpe::command { 'check_memory':

--- a/manifests/plugin/nrpe_swap.pp
+++ b/manifests/plugin/nrpe_swap.pp
@@ -1,12 +1,12 @@
 # Export Nagios service for check_swap
 class nagios::plugin::nrpe_swap (
-  String $max_check_attempts,
-  String $check_interval,
   $ensure                        = 'present',
   $warn                          = 20,
   $crit                          = 10,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
+  String $check_interval         = $nagios::params::check_interval,
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
 ){
   # Configure nrpe directories first
   include nrpe

--- a/manifests/plugin/nrpe_swap.pp
+++ b/manifests/plugin/nrpe_swap.pp
@@ -4,7 +4,9 @@ class nagios::plugin::nrpe_swap (
   $warn                          = 20,
   $crit                          = 10,
   Integer $notification_interval = lookup('nagios::notification_interval'),
-  String $notification_period    = lookup('nagios::notification_period')
+  String $notification_period    = lookup('nagios::notification_period'),
+  String $max_check_attempts     = $nagios::params::max_check_attempts,
+  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe
@@ -23,6 +25,8 @@ class nagios::plugin::nrpe_swap (
       notification_interval => $notification_interval,
       notification_period   => $notification_period,
       require               => Class['nagios'],
+      check_interval        => $check_interval,
+      max_check_attempts    => $max_check_attempts,
     }
   }
 

--- a/manifests/plugin/nrpe_swap.pp
+++ b/manifests/plugin/nrpe_swap.pp
@@ -1,12 +1,12 @@
 # Export Nagios service for check_swap
 class nagios::plugin::nrpe_swap (
+  String $max_check_attempts,
+  String $check_interval,
   $ensure                        = 'present',
   $warn                          = 20,
   $crit                          = 10,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
-  String $max_check_attempts     = $nagios::params::max_check_attempts,
-  String $check_interval         = $nagios::params::check_interval
 ){
   # Configure nrpe directories first
   include nrpe


### PR DESCRIPTION
These values should be set per environment in the Puppet control repo.
```
nagios::plugin::nrpe_memory::check_interval: '0.5'
nagios::plugin::nrpe_memory::max_check_attempts: '3'

nagios::plugin::nrpe_core_load::max_check_attempts: '5'
nagios::plugin::nrpe_core_load::check_interval: '1'

nagios::plugin::nrpe_disks::max_check_attempts: '5'
nagios::plugin::nrpe_disks::check_interval: '2'

nagios::plugin::nrpe_swap::max_check_attempts: '3'
nagios::plugin::nrpe_swap::check_interval: '1'

nagios::plugin::check_ping::max_check_attempts: '10'
nagios::plugin::check_ping::check_interval: '0.25'
```
Some discussion will have to take place on what the values should be for each environment.

Note that these variables were only added to some checks.
The other checks could (and some should?) have the variables added, but this will require some discussion.

