### PR TITLE
Add support for excluding mount points

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,4 +21,5 @@ class nagios::params {
   $nrpe_timeout_seconds  = 30
   $check_interval        = '1'
   $max_check_attempts    = '5'
+  $excluded_mount_points = []
 }

--- a/manifests/plugin/nrpe_disks.pp
+++ b/manifests/plugin/nrpe_disks.pp
@@ -3,15 +3,22 @@ class nagios::plugin::nrpe_disks (
   $warn                          = '5%',
   $crit                          = '2%',
   # lint:ignore:140chars
-  $check_disks_command           = "check_disk -l -L -w ${warn} -c ${crit} -e -f -M -A -X configfs -X cgroup -X selinuxfs -X sysfs -X proc -X mqueue -X binfmt_misc -X devtmpfs",
+  $default_check_disks_command = "check_disk -l -L -w ${warn} -c ${crit} -e -f -M -A -X configfs -X cgroup -X selinuxfs -X sysfs -X proc -X mqueue -X binfmt_misc -X devtmpfs",
   # lint:endignore
-  Integer $notification_interval = lookup('nagios::notification_interval'),
-  String $notification_period    = lookup('nagios::notification_period'),
-  String $check_interval         = $nagios::params::check_interval,
-  String $max_check_attempts     = $nagios::params::max_check_attempts,
+  Integer $notification_interval       = lookup('nagios::notification_interval'),
+  String $notification_period          = lookup('nagios::notification_period'),
+  String $check_interval               = $nagios::params::check_interval,
+  String $max_check_attempts           = $nagios::params::max_check_attempts,
+  Array[String] $excluded_mount_points = $nagios::params::excluded_mount_points
 ){
   # Configure nrpe directories first
   include nrpe
+
+  $excluded_mount_point_command = $excluded_mount_points.reduce('') | String $acc, String $mount_point | {
+    "${acc} -i ${mount_point}"
+  }
+
+  $check_disks_command = "${default_check_disks_command}${excluded_mount_point_command}"
 
   # NRPE Command
   nrpe::command { 'check_disks':

--- a/manifests/plugin/nrpe_memory.pp
+++ b/manifests/plugin/nrpe_memory.pp
@@ -1,8 +1,8 @@
 # Export Nagios service for check_memory
 class nagios::plugin::nrpe_memory (
   $ensure                        = 'present',
-  $warn                          = 75,
-  $crit                          = 85,
+  $warn                          = 90,
+  $crit                          = 95,
   Integer $notification_interval = lookup('nagios::notification_interval'),
   String $notification_period    = lookup('nagios::notification_period'),
   String $check_interval         = $nagios::params::check_interval,
@@ -16,12 +16,7 @@ class nagios::plugin::nrpe_memory (
       source => 'puppet:///modules/nagios/check_memory',
       notify => Service['nrpe'],
   }
-
-  file {'/opt/test':
-    ensure  => present,
-    content => "${check_interval} - ${max_check_attempts}"
-  }
-
+  
   nrpe::command { 'check_memory':
     ensure  => $ensure,
     command => "check_memory -w ${warn} -c ${crit}";


### PR DESCRIPTION
Allow passing of array of mount points that will be excluded from nagios disk_space checks.

```
nagios::plugins::nrpe_disks::excluded_mount_points
```

The mount point can be listed as either the mount point or the partition, e.g.
```
$excluded_mount_points = ['/opt', '/dev/mapper/vg01-tmp']
```

Note that if no mount points are to be ignored, an empty array should be provided (this is the default value).
