### PR TITLE
check app fact length

### DIFF
--- a/manifests/export_resources.pp
+++ b/manifests/export_resources.pp
@@ -18,7 +18,7 @@ class nagios::export_resources (
   $app_fact = $trusted['extensions']['pp_application']
 
   $app_fact_contact_group =
-    if $app_fact == undef {
+    if $app_fact == undef or length($app_fact) == 0 {
       ''
     }
     else {


### PR DESCRIPTION
A blank (but existent) app fact means that we end up with an error. This adds a check to make sure the app fact isn't blank.